### PR TITLE
Support XDG_CONFIG_HOME env

### DIFF
--- a/commands/edit.go
+++ b/commands/edit.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func findIdFromQueryIndex(queryIndex int) (string, error) {
-	bs, err := ioutil.ReadFile(conf.HomeDir + "/.borg/query")
+	bs, err := ioutil.ReadFile(conf.QueryFile)
 	if err != nil {
 		return "", err
 	}
@@ -74,12 +74,12 @@ func Edit(args []string) error {
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile(conf.HomeDir+"/.borg/edit", []byte(str), 0755)
-	cmd := exec.Command(c.Editor, conf.HomeDir+"/.borg/edit")
+	ioutil.WriteFile(conf.EditFile, []byte(str), 0755)
+	cmd := exec.Command(c.Editor, conf.EditFile)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Run()
-	bs, err := ioutil.ReadFile(conf.HomeDir + "/.borg/edit")
+	bs, err := ioutil.ReadFile(conf.EditFile)
 	if err != nil {
 		return err
 	}

--- a/commands/new.go
+++ b/commands/new.go
@@ -40,11 +40,11 @@ func New([]string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(c.Editor, conf.HomeDir+"/.borg/edit")
+	cmd := exec.Command(c.Editor, conf.EditFile)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Run()
-	bs, err := ioutil.ReadFile(conf.HomeDir + "/.borg/edit")
+	bs, err := ioutil.ReadFile(conf.EditFile)
 	if err != nil {
 		return err
 	}

--- a/commands/query.go
+++ b/commands/query.go
@@ -117,7 +117,7 @@ func writeToFile(query string, ps []types.Problem) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(conf.HomeDir+"/.borg/query", bs, 0755)
+	return ioutil.WriteFile(conf.QueryFile, bs, 0755)
 }
 
 func host() string {

--- a/commands/worked.go
+++ b/commands/worked.go
@@ -43,7 +43,7 @@ func Worked(args []string) error {
 }
 
 func getLastQuery() (string, error) {
-	bs, err := ioutil.ReadFile(conf.HomeDir + "/.borg/query")
+	bs, err := ioutil.ReadFile(conf.QueryFile)
 	if err != nil {
 		return "", err
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -63,15 +63,19 @@ func init() {
 }
 
 func borgDir() string {
-	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
-		return filepath.Join(xdgConfigHome, "borg")
-	}
-
 	usr, err := user.Current()
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(usr.HomeDir, ".borg")
+	dir := filepath.Join(usr.HomeDir, ".borg")
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+			dir = filepath.Join(xdgConfigHome, "borg")
+		}
+	}
+
+	return dir
 }
 
 // Config file


### PR DESCRIPTION
Support `XDG_CONFIG_HOME` environment variable.
And fix hardcoded filepath(`/`) separator, exported `EditFile`, `ConfigFile` and `QueryFile`.

I'm a macOS user, but many command line tools supported `XDG_CONFIG_HOME`. So I'm glad if borg also supports that environment.
Note that added backward compatibility that uses the`$HOME/.borg` if already exists.

---

This includes small personal opinion. Feel free to reject this pull request if you don't like it.